### PR TITLE
Two Improvements

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -2,6 +2,7 @@ package goics
 
 import (
 	"io"
+	"sort"
 	"strings"
 	"time"
 )
@@ -35,11 +36,18 @@ type Component struct {
 // Writes the component to the Writer
 func (c *Component) Write(w *ICalEncode) {
 	w.WriteLine("BEGIN:" + c.Tipo + CRLF)
-	// Iterate over component properites
-	for key, val := range c.Properties {
-		w.WriteLine(WriteStringField(key, val))
 
+	// Iterate over component properites
+	var keys []string
+	for k := range c.Properties {
+		keys = append(keys, k)
 	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		val := c.Properties[key]
+		w.WriteLine(WriteStringField(key, val))
+	}
+
 	for _, xc := range c.Elements {
 		xc.Write(w)
 	}
@@ -136,5 +144,6 @@ func quoteString(s string) string {
 	s = strings.Replace(s, "\\,", ",", -1)
 	s = strings.Replace(s, "\\n", "\n", -1)
 	s = strings.Replace(s, "\\\\", "\\", -1)
+
 	return s
 }

--- a/encoder.go
+++ b/encoder.go
@@ -140,10 +140,10 @@ func WriteStringField(key string, val string) string {
 }
 
 func quoteString(s string) string {
-	s = strings.Replace(s, "\\;", ";", -1)
-	s = strings.Replace(s, "\\,", ",", -1)
-	s = strings.Replace(s, "\\n", "\n", -1)
-	s = strings.Replace(s, "\\\\", "\\", -1)
+	s = strings.Replace(s, "\\", "\\\\", -1)
+	s = strings.Replace(s, ";", "\\;", -1)
+	s = strings.Replace(s, ",", "\\,", -1)
+	s = strings.Replace(s, "\n", "\\n", -1)
 
 	return s
 }

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -147,10 +147,9 @@ func TestLineWriterLongLine(t *testing.T) {
 	}
 }
 
-
 func Test2ongLineWriter(t *testing.T) {
 	goics.LineSize = 10
-	
+
 	w := &bytes.Buffer{}
 
 	result := &bytes.Buffer{}


### PR DESCRIPTION
I've made two minor improvements to this library.

- The first improvement (9e1aec4) makes the output of the ICS generator deterministic. This lets the ICS data be properly cached which significantly reduces server bandwidth for deployments that have a large number of subscribers but do not change the calendar very often.

- The second improvement (c826fec) fixes character escaping. On iOS Devices in particular, if a location had a comma the line would be truncated at the comma. Now it will instead escape commas, line breaks, semicolons, and backslashes.