### PR TITLE
Fix tests for Go 1.10 format checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,11 @@
 language: go
+
+matrix:
+  include:
+    - go: "tip"
+    - go: "1.x"
+    - go: "1.10"
+    - go: "1.9"
+    - go: "1.8"
+  allow_failures:
+    - go: tip

--- a/decoder_line_test.go
+++ b/decoder_line_test.go
@@ -34,14 +34,14 @@ func TestDecodeLine(t *testing.T) {
 		t.Errorf("Wrong val parsing %s", node.Val)
 	}
 	if node.ParamsLen() != 2 {
-		t.Errorf("Wrong nmber of params %s", node.ParamsLen())
+		t.Errorf("Wrong nmber of params %d", node.ParamsLen())
 	}
 	node = goics.DecodeLine(TLines[2])
 	if node.Key != "X-FOO" {
 		t.Errorf("Wrong key parsing %s", node.Key)
 	}
 	if node.ParamsLen() != 2 {
-		t.Errorf("Incorrect quoted params count %s, %d", node.ParamsLen(), node.Params)
+		t.Errorf("Incorrect quoted params count %d, %v", node.ParamsLen(), node.Params)
 
 	}
 	node = goics.DecodeLine(TLines[3])
@@ -49,7 +49,7 @@ func TestDecodeLine(t *testing.T) {
 		t.Errorf("Wrong key parsing %s", node.Key)
 	}
 	if node.ParamsLen() != 3 {
-		t.Errorf("Incorrect quoted params count %s, %d", node.ParamsLen(), node.Params)
+		t.Errorf("Incorrect quoted params count %d, %v", node.ParamsLen(), node.Params)
 	}
 	if node.Params["ROLE"] != "REQ-PARTICIPANT;foo" {
 		t.Errorf("Error extracting quoted params from line %s", node.Params["ROLE"])

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -41,7 +41,7 @@ func TestEndOfFile(t *testing.T) {
 		t.Errorf("Decode filed, decode raised %s", err)
 	}
 	if a.Lines() != 3 {
-		t.Errorf("Decode should advance to %s", a.Lines())
+		t.Errorf("Decode should advance to %d", a.Lines())
 	}
 
 }
@@ -201,7 +201,7 @@ func TestReadingRealFile(t *testing.T) {
 	}
 
 	if len(cal.Calendar.Events) != 28 {
-		t.Errorf("Wrong number of events detected %s", len(cal.Calendar.Events))
+		t.Errorf("Wrong number of events detected %d", len(cal.Calendar.Events))
 	}
 
 }


### PR DESCRIPTION
Go 1.10 added checks when testing that the correct formatting "verbs" are being used. This test addresses a the tests that were using the wrong verbs so that this package can be used with Go 1.10.

Also updated the Travis CI configuration to test against multiple Go versions. Looks like one of the dependencies [fails on Go 1.7 and earlier](https://travis-ci.org/harrisonhjones/goics/builds/376693427) so only added 1.8+.