### PR TITLE
deal with multilines with len lower than 65 chars

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -95,26 +95,20 @@ func (d *decoder) next() {
 		d.buffered = ""
 	}
 
-	if len(d.current) > 65 {
-		isContinuation := true
-		for isContinuation == true {
-			res := d.scanner.Scan()
-			d.line++
-			if true != res {
-				d.err = d.scanner.Err()
-				return
-			}
-			line := d.scanner.Text()
-			if strings.HasPrefix(line, " ") || strings.HasPrefix(line, "\t") {
-				d.current = d.current + line[1:]
-			} else {
-				// If is not a continuation line, buffer it, for the
-				// next call.
-				d.buffered = line
-				isContinuation = false
-			}
+	for d.scanner.Scan() {
+		d.line++
+		line := d.scanner.Text()
+		if strings.HasPrefix(line, " ") || strings.HasPrefix(line, "\t") {
+			d.current = d.current + line[1:]
+		} else {
+			// If is not a continuation line, buffer it, for the
+			// next call.
+			d.buffered = line
+			break
 		}
 	}
+
+	d.err = d.scanner.Err()
 
 	if d.nextFn != nil {
 		d.nextFn(d)

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -314,3 +314,44 @@ func TestDataMultipleAtendee(t *testing.T) {
 	}
 
 }
+
+var dataMultiline = `BEGIN:VCALENDAR
+BEGIN:VEVENT
+ORGANIZER:Mailto:B@example.com
+ATTENDEE;
+ ROLE=CHAIR;
+  PARTSTAT
+   =ACCEPTED;CN=
+    BIG A
+	 :Mailto:A@example.com
+ATTENDEE;RSVP=TRUE;CUTYPE=INDIVIDUAL;
+ CN=B:Mailto:B@example.com
+ATTENDEE;RSVP=TRUE;CUTYPE=INDIVIDUAL;CN=C:Mailto:C@example.com
+DTSTAMP:19970611T193000Z
+DTSTART:19970701T190000Z
+DTEND:19970701T193000Z
+UID:calsrv.example.com-873970198738777@example.com
+SUMMARY: Pool party
+END:VEVENT
+END:VCALENDAR`
+
+func TestMulitine(t *testing.T) {
+
+	d := goics.NewDecoder(strings.NewReader(dataMultiline))
+	consumer := EventsA{}
+	err := d.Decode(&consumer)
+	if err != nil {
+		t.Errorf("Error decoding events %+v", err)
+	}
+	if len(consumer) != 1 {
+		t.Error("Wrong size of consumer list..")
+	}
+
+	if size := len(consumer[0].Attendees); size != 3 {
+		t.Errorf("Wrong size of attendees detected %d", size)
+	}
+
+	if att := consumer[0].Attendees[0]; att != "Mailto:A@example.com" {
+		t.Errorf("Attendees list should be %s", att)
+	}
+}

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -46,6 +46,22 @@ func TestEndOfFile(t *testing.T) {
 
 }
 
+var sourceEOFMultiline = `BEGIN:VCALENDAR
+VERSION:2.0
+ FOO
+  BAR
+   BAR
+`
+
+func TestEndOfFileMultiline(t *testing.T) {
+	a := goics.NewDecoder(strings.NewReader(sourceEOFMultiline))
+	a.Decode(&Calendar{})
+	if expected := 5; a.Lines() != expected {
+		t.Errorf("Decode should advance to %d but %d is returned", expected, a.Lines())
+	}
+
+}
+
 var test2 = `BEGIN:VCALENDAR
 PRODID;X-RICAL-TZSOURCE=TZINFO:-//test//EN
 CALSCALE:GREGORIAN


### PR DESCRIPTION
As define into the rfc, a multiline content can be lower than 65 characters.

```
   Lines of text SHOULD NOT be longer than 75 octets, excluding the line
   break.  Long content lines SHOULD be split into a multiple line
   representations using a line "folding" technique.  That is, a long
   line can be split between any two characters by inserting a CRLF
   immediately followed by a single linear white-space character (i.e.,
   SPACE or HTAB).  Any sequence of CRLF followed immediately by a
   single linear white-space character is ignored (i.e., removed) when
   processing the content type.

   For example, the line:

     DESCRIPTION:This is a long description that exists on a long line.

   Can be represented as:

     DESCRIPTION:This is a lo
      ng description
       that exists on a long line.
```

 https://tools.ietf.org/html/rfc5545#section-3.1

So I removed the len test for the current line and try to find continuation if exists in all cases.