### PR TITLE
unescape node values

### DIFF
--- a/decoder_line.go
+++ b/decoder_line.go
@@ -51,7 +51,7 @@ func DecodeLine(line string) *IcsNode {
 			Key: key,
 			Val: val,
 		}
-	} 
+	}
 	// Extract key
 	firstParam := strings.Index(key, vParamSep)
 	realkey := key[0:firstParam]
@@ -108,5 +108,13 @@ func decodeParams(arr string) map[string]string {
 // Returns a key, val... for a line..
 func getKeyVal(s string) (key, value string) {
 	p := strings.SplitN(s, keySep, 2)
-	return p[0], p[1]
+	return p[0], icsReplacer.Replace(p[1])
 }
+
+var icsReplacer = strings.NewReplacer(
+	`\,`, ",",
+	`\;`, ";",
+	`\\`, `\`,
+	`\n`, "\n",
+	`\N`, "\n",
+)

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -185,6 +185,25 @@ func TestNotParsingValarm(t *testing.T) {
 	}
 }
 
+var testEscapeValue = `BEGIN:VCALENDAR
+X-TEST:one\, two\, three\n\Nfour\;five\\six
+END:VCALENDAR`
+
+func TestUnescapeValue(t *testing.T) {
+	a := goics.NewDecoder(strings.NewReader(testEscapeValue))
+	cons := NewCal()
+	err := a.Decode(cons)
+
+	if err != nil {
+		t.Errorf("Error decoding %s", err)
+	}
+
+	expected := "one, two, three\n\nfour;five\\six"
+	if actual := cons.Data["X-TEST"]; expected != actual {
+		t.Errorf("unexpected summary: %q", actual)
+	}
+}
+
 func TestReadingRealFile(t *testing.T) {
 
 	file, err := os.Open("fixtures/test.ics")


### PR DESCRIPTION
I saw some `\escaped` chars show up in a parsed event, and tracked it down to this line in an ics VEVENT from an Apple ICal feed.

```
LOCATION:Colorado Convention Center\n700 14th St\, Denver\, CO  80202\, U
 nited States
```

It's not just apple either. Here's a snippet from my Google Calendar's ics feed:

```
DESCRIPTION:To see detailed information for automatically created events li
 ke this one\, use the official Google Calendar app. 
```

This patch should take care of it. However, I noticed that [the spec](https://tools.ietf.org/html/rfc5545#section-3.1) says property values don't need to be escaped, just unquoted param values (which doesn't apply to the above `DESCRIPTION`). Here are the relevant lines:

```
contentline   = name *(";" param ) ":" value CRLF
value         = *VALUE-CHAR
VALUE-CHAR    = WSP / %x21-7E / NON-US-ASCII
; Any textual character

param         = param-name "=" param-value *("," param-value)
param-name    = iana-token / x-name
param-value   = paramtext / quoted-string
paramtext     = *SAFE-CHAR

SAFE-CHAR     = WSP / %x21 / %x23-2B / %x2D-39 / %x3C-7E
    / NON-US-ASCII
; Any character except CONTROL, DQUOTE, ";", ":", ","
```

I'm curious if you have much experience parsing Apple ICal or Google Calendar feeds. Is this worth including since two big calendar products need it, even if it doesn't seem to be strictly part of the spec?