### PR TITLE
Don't split codepoints when splitting long lines (improved).

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -102,21 +102,21 @@ func (enc *ICalEncode) WriteLine(s string) {
 		io.WriteString(enc.w, s)
 		return
 	}
-	length := len(s)
-	current := 0
-	// LineSize -2 is CRLF
-	shortLine := LineSize - 2
-	// First line write from 0 to totalline - 2 ( must include CRLFS)
-	io.WriteString(enc.w, s[current:current+(shortLine)]+CRLFSP)
-	current = shortLine
-	// Rest of lines, we must include ^space at begining for marquing
-	// continuation lines
-	for (current + shortLine) <= length {
-		io.WriteString(enc.w, s[current:current+(shortLine-1)]+CRLFSP)
-		current += shortLine - 1
+
+	// The first line does not begin with a space.
+	firstLine := truncateString(s, LineSize-len(CRLF))
+	io.WriteString(enc.w, firstLine+CRLF)
+
+	// Reserve three bytes for space + CRLF.
+	lines := splitLength(s[len(firstLine):], LineSize-len(CRLFSP))
+	for i, line := range lines {
+		if i < len(lines)-1 {
+			io.WriteString(enc.w, " "+line+CRLF)
+		} else {
+			// This is the last line, don't append CRLF.
+			io.WriteString(enc.w, " "+line)
+		}
 	}
-	// Also we need to write the reminder
-	io.WriteString(enc.w, s[current:length])
 }
 
 // FormatDateField returns a formated date: "DTEND;VALUE=DATE:20140406"

--- a/string.go
+++ b/string.go
@@ -1,0 +1,40 @@
+package goics
+
+// splitLength returns a slice of strings, each string is at most length bytes long.
+// Does not break UTF-8 codepoints.
+func splitLength(s string, length int) []string {
+	var ret []string
+
+	for len(s) > 0 {
+		tmp := truncateString(s, length)
+		if len(tmp) == 0 {
+			// too short length, or invalid UTF-8 string
+			break
+		}
+		ret = append(ret, tmp)
+		s = s[len(tmp):]
+	}
+
+	return ret
+}
+
+// truncateString truncates s to a maximum of length bytes without breaking UTF-8 codepoints.
+func truncateString(s string, length int) string {
+	if len(s) <= length {
+		return s
+	}
+
+	// UTF-8 continuation bytes start with 10xx xxxx:
+	// 0xc0 = 1100 0000
+	// 0x80 = 1000 0000
+	cutoff := length
+	for s[cutoff]&0xc0 == 0x80 {
+		cutoff--
+		if cutoff < 0 {
+			cutoff = 0
+			break
+		}
+	}
+
+	return s[0:cutoff]
+}

--- a/string_test.go
+++ b/string_test.go
@@ -1,0 +1,74 @@
+package goics
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestTruncateString(t *testing.T) {
+	tests := []struct {
+		input  string
+		want   string
+		length int
+	}{
+		{"Anders", "And", 3},
+		{"åååååå", "ååå", 6},
+		// Hiragana a times 4
+		{"\u3042\u3042\u3042\u3042", "\u3042", 4},
+		{"\U0001F393", "", 1},
+		// Continuation bytes
+		{"\x80\x80", "", 1},
+	}
+	for _, test := range tests {
+		if got := truncateString(test.input, test.length); got != test.want {
+			t.Errorf("expected %q, got %q", test.want, got)
+		}
+	}
+}
+
+func TestSplitLength(t *testing.T) {
+	tests := []struct {
+		input string
+		len   int
+		want  []string
+	}{
+		{
+			"AndersSrednaFoobarBazbarX",
+			6,
+			[]string{"Anders", "Sredna", "Foobar", "Bazbar", "X"},
+		},
+		{
+			"AAAA\u00c5\u00c5\u00c5\u00c5\u3042\u3042\u3042\u3042\U0001F393\U0001F393\U0001F393\U0001F393",
+			4,
+			[]string{
+				"AAAA",                         // 1 byte
+				"\u00c5\u00c5", "\u00c5\u00c5", // 2 bytes
+				"\u3042", "\u3042", "\u3042", "\u3042", // 3 bytes
+				"\U0001F393", "\U0001F393", "\U0001F393", "\U0001F393", // 4 bytes
+			},
+		},
+		{
+			"\u3042\u3042\u3042\u3042",
+			8,
+			[]string{"\u3042\u3042", "\u3042\u3042"},
+		},
+		{
+			"\u3042",
+			2,
+			nil,
+		},
+	}
+	for _, tt := range tests {
+		if got := splitLength(tt.input, tt.len); !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("splitLength() = %v, want %v", got, tt.want)
+		}
+	}
+}
+
+func BenchmarkTruncateString(b *testing.B) {
+	longString := strings.Repeat("\u3042", 100)
+	for i := 0; i < b.N; i++ {
+		truncateString(longString, 150)
+	}
+}


### PR DESCRIPTION
I messed up the previous pull request #9 and it got closed, anyway, this is an improved patch. It will ensure the line lengths don't exceed LineSize while keeping UTF-8 codepoints intact.

Test program:
```go
s := ical.NewComponent()
buf := &bytes.Buffer{}
w := ical.NewICalEncode(buf)
s.AddProperty("SUMMARY", strings.Repeat("å", 200))
s.Write(w)
tmp := strings.Split(buf.String(), "\r\n")
for i, l := range tmp {
	log.Printf("tmp[%d] = #%d; %q", i, len(l), l)
}
```

Output: (length and string output exclude \r\n because of strings.Split)
```
 tmp[0] = #6; "BEGIN:"
 tmp[1] = #72; "SUMMARY:åååååååååååååååååååååååååååååååå"
 tmp[2] = #73; " åååååååååååååååååååååååååååååååååååå"
 tmp[3] = #73; " åååååååååååååååååååååååååååååååååååå"
 tmp[4] = #73; " åååååååååååååååååååååååååååååååååååå"
 tmp[5] = #73; " åååååååååååååååååååååååååååååååååååå"
 tmp[6] = #49; " åååååååååååååååååååååååå"
 tmp[7] = #4; "END:"
 tmp[8] = #0; ""
```