### PR TITLE
Add support for encoding multiple properties with the same key

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -21,7 +21,7 @@ const (
 func NewComponent() *Component {
 	return &Component{
 		Elements:   make([]Componenter, 0),
-		Properties: make(map[string]string),
+		Properties: make(map[string][]string),
 	}
 }
 
@@ -30,22 +30,24 @@ func NewComponent() *Component {
 type Component struct {
 	Tipo       string
 	Elements   []Componenter
-	Properties map[string]string
+	Properties map[string][]string
 }
 
 // Writes the component to the Writer
 func (c *Component) Write(w *ICalEncode) {
 	w.WriteLine("BEGIN:" + c.Tipo + CRLF)
 
-	// Iterate over component properites
+	// Iterate over component properties
 	var keys []string
 	for k := range c.Properties {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
 	for _, key := range keys {
-		val := c.Properties[key]
-		w.WriteLine(WriteStringField(key, val))
+		vals := c.Properties[key]
+		for _, val := range vals {
+			w.WriteLine(WriteStringField(key, val))
+		}
 	}
 
 	for _, xc := range c.Elements {
@@ -67,9 +69,9 @@ func (c *Component) AddComponent(cc Componenter) {
 	c.Elements = append(c.Elements, cc)
 }
 
-// AddProperty ads a property to the component
+// AddProperty adds a property to the component.
 func (c *Component) AddProperty(key string, val string) {
-	c.Properties[key] = val
+	c.Properties[key] = append(c.Properties[key], val)
 }
 
 // ICalEncode is the real writer, that wraps every line,

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -16,13 +16,14 @@ func TestComponentCreation(t *testing.T) {
 	c.AddProperty("CALSCAL", "GREGORIAN")
 	c.AddProperty("PRODID", "-//tmpo.io/src/goics")
 
-	if c.Properties["CALSCAL"] != "GREGORIAN" {
-		t.Error("Error setting property")
+	if c.Properties["CALSCAL"][0] != "GREGORIAN" {
+		t.Error("Error adding property")
 	}
 
 	m := goics.NewComponent()
 	m.SetType("VEVENT")
-	m.AddProperty("UID", "testing")
+	m.AddProperty("UID", "testing1")
+	m.AddProperty("UID", "testing2") // Not that you'd ever _want_ to have multiple UIDs but for testing this is fine.
 
 	c.AddComponent(m)
 
@@ -30,6 +31,20 @@ func TestComponentCreation(t *testing.T) {
 		t.Error("Error adding a component")
 	}
 
+	ins := &EventTest{
+		component: c,
+	}
+
+	w := &bytes.Buffer{}
+	enc := goics.NewICalEncode(w)
+	enc.Encode(ins)
+
+	want := "BEGIN:VCALENDAR\r\nCALSCAL:GREGORIAN\r\nPRODID:-//tmpo.io/src/goics\r\nBEGIN:VEVENT\r\nUID:testing1\r\nUID:testing2\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n"
+	got := w.String()
+
+	if got != want {
+		t.Errorf("encoded value mismatch:\ngot:\n%s\n\nwant:\n%s", got, want)
+	}
 }
 
 type EventTest struct {


### PR DESCRIPTION
**Motivation**

I am trying to add multiple `ATTENDEE` properties to a `VEVENT` components. I realized that I couldn't (easily) do this using the `AddProperty` method. In my opinion it should have been called `SetProperty` but that could come in another PR. This update changes the way `AddProperty` works to make it a true "add" and not a "set".

**Changes**

1. Updated `AddProperty` to act like a true "add" operation instead of a "set" operation.
1. Updated the tests to check for this new behavior.
1. Formatted the project with `gofmt` which added a _bit_ of noise to the diff.