### PR TITLE
Remove unsupported go 1.8 and 1.9 from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,5 @@ matrix:
     - go: "1.12"
     - go: "1.11"
     - go: "1.10"
-    - go: "1.9"
-    - go: "1.8"
   allow_failures:
     - go: tip


### PR DESCRIPTION
As brought up in https://github.com/jordic/goics/pull/16 this PR removes go 1.8 and 1.9 from our Travis CI build. Building on 1.8 and 1.9 is broken and unsupported.

# Testing

Pushed this change to my fork. Checked that the build succeeded in Travis: https://travis-ci.org/github/harrisonhjones/goics/builds/765948040